### PR TITLE
Fixed invalid links

### DIFF
--- a/custom_components/HomeWhiz/manifest.json
+++ b/custom_components/HomeWhiz/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "HomeWhiz",
   "name": "HomeWhiz",
-  "documentation": "https://github.com/rowysock/HomeWhiz",
-  "issue_tracker": "https://github.com/rowysock/HomeWhiz/issues",
+  "documentation": "https://github.com/rowysock/home-assistant-HomeWhiz",
+  "issue_tracker": "https://github.com/rowysock/home-assistant-HomeWhiz/issues",
   "config_flow": true,
   "codeowners": [
     "@rowysock"

--- a/custom_components/HomeWhiz/translations/bg.json
+++ b/custom_components/HomeWhiz/translations/bg.json
@@ -1,0 +1,31 @@
+{
+    "config": {
+      "abort": {
+        "already_configured": "Устройството вече е конфигурирано",
+        "no_devices": "Няма намерени устройства."
+      },
+      "error": {
+        "cannot_connect": "Неуспешно свързване",
+        "unknown": "Неочаквана грешка"
+      },
+      "step": {
+        "devices": {
+          "title": "Изберете устройство",
+          "data": {
+            "device": "Устройство"
+          }
+        },
+        "confirm": {
+          "description": "Искате ли да конфигурирате HomeWhiz?"
+        }
+      },
+      "progress": {
+        "scan_task": "Търсене на устройства..."
+      }
+    },
+    "options": {
+        "abort": {
+          "no_devices": "Няма намерени устройства."
+        }
+    }
+  }


### PR DESCRIPTION
The file [manifest.json](https://github.com/rowysock/home-assistant-HomeWhiz/blob/main/custom_components/HomeWhiz/manifest.json) contains invalid links: 
  "documentation": "https://github.com/rowysock/HomeWhiz",
  "issue_tracker": "https://github.com/rowysock/HomeWhiz/issues",