### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/custom_components/homewhiz/manifest.json
+++ b/custom_components/homewhiz/manifest.json
@@ -12,7 +12,7 @@
     "bleak"
   ],
   "dependencies": ["bluetooth"],
-  "version": "0.0.3",
+  "version": "0.0.6",
   "bluetooth": [
     {
       "connectable": false,


### PR DESCRIPTION
Prior to adding the repository to HACS, we should release a new version. Especially because of the domain name change, which (at least for me) required removing and adding the integration again.

HACS PR: https://github.com/hacs/default/pull/1587