### PR TITLE
Added Device Substate for value 0

### DIFF
--- a/custom_components/homewhiz/homewhiz.py
+++ b/custom_components/homewhiz/homewhiz.py
@@ -23,6 +23,7 @@ class DeviceState(Enum):
 
 
 class DeviceSubState(Enum):
+    OFF = 0
     WASHING = 1
     SPIN = 2
     WATER_INTAKE = 3


### PR DESCRIPTION
Hey @rowysock, 

I noticed that, when switched off, my washing machine reports Substate as 0, so I thought I would submit this patch to address it.

This should address the following entry in the HA logs:

` WARNING (MainThread) [custom_components.homewhiz] Unknown DeviceSubState: 0`

Please let me know if you require any additional information.

Cheers
Louwrens

Signed-off-by: Louwrens Benade <iamthekamakazi@live.co.za>