### PR TITLE
Improve reconnection logic

### DIFF
--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -1,5 +1,5 @@
+import asyncio
 import logging
-import time
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
@@ -105,7 +105,7 @@ class HomewhizDataUpdateCoordinator(DataUpdateCoordinator[WasherState | None]):
                 _LOGGER.info(
                     f"[{self.address}] Can't reconnect. Waiting a minute to try again"
                 )
-                time.sleep(60)
+                await asyncio.sleep(60)
 
     @callback
     def handle_disconnect(self):


### PR DESCRIPTION
Using bluetooth.async_register_callback is not enough when the connection is lost disconnects for a short period of time. The bluetooth device can be available even for a few minutes after physical device becomes unavailable. If that happens, and physical device becomes available no discovery callback is triggered. We have to actively try to connect to the device