### PR TITLE
Add attr_has_entity_name to HomeWhizEntity

### DIFF
--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -174,6 +174,8 @@ def generate_descriptions_from_config(
 
 
 class HomeWhizEntity(CoordinatorEntity[HomewhizCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: HomewhizCoordinator,


### PR DESCRIPTION
Fixes #58. Requires removing and adding the Homewhiz device.